### PR TITLE
Better parsing

### DIFF
--- a/lib/body.js
+++ b/lib/body.js
@@ -1,4 +1,4 @@
-const { compose, curry, path, tap } = require('ramda')
+const { compose, curry, path } = require('ramda')
 const { PassThrough } = require('stream')
 const rawBody         = require('raw-body')
 const typer           = require('media-typer')

--- a/lib/body.js
+++ b/lib/body.js
@@ -1,16 +1,17 @@
-const { compose, curryN, path } = require('ramda')
+const { compose, curry, path, tap } = require('ramda')
 const { PassThrough } = require('stream')
 const rawBody         = require('raw-body')
 const typer           = require('media-typer')
 
 const contentLength = compose(parseInt, path(['headers', 'content-length']))
+const contentType   = path(['headers', 'content-type'])
 
-const parseBody = curryN(2, (deserialize, res) => {
-  const length = contentLength(res)
-  if (!length) return Promise.resolve(null)
-  const encoding = typer.parse(res).parameters.charset || 'utf8'
+const parseBody = (deserialize, res) => {
+  const length   = contentLength(res)
+  const type     = contentType(res)
+  const encoding = type && typer.parse(type).parameters.charset || 'utf8'
   return rawBody(res, { encoding, length }).then(deserialize)
-})
+}
 
 const streamBody = res => {
   const body = new PassThrough()
@@ -19,6 +20,6 @@ const streamBody = res => {
 }
 
 module.exports = {
-  parseBody,
+  parseBody: curry(parseBody),
   streamBody
 }

--- a/lib/gimme.js
+++ b/lib/gimme.js
@@ -1,4 +1,3 @@
-const Boom  = require('boom')
 const http  = require('http')
 const https = require('https')
 const qs    = require('qs')
@@ -10,7 +9,9 @@ const {
   length, merge, pick, pipe, replace, when
 } = require('ramda')
 
-const { parseBody, streamBody } = require('./body')
+const parseBody  = require('./parseBody')
+const streamBody = require('./streamBody')
+const wrapError  = require('./wrapError')
 
 const redact = evolve({ 'authorization': replace(/\s(.*)/, ' REDACTED') })
 
@@ -18,6 +19,8 @@ const clean = pipe(
   pick(['body', 'headers', 'statusCode', 'statusMessage']),
   evolve({ headers: redact })
 )
+
+const parseJSON = when(length, JSON.parse)
 
 const gimme = opts => {
   const { json = true } = opts
@@ -81,13 +84,6 @@ const gimme = opts => {
       req.end()
     }
   })
-}
-
-const parseJSON = when(length, JSON.parse)
-
-const wrapError = context => {
-  const { statusCode, statusMessage } = context.res
-  return Boom.create(statusCode, statusMessage, context)
 }
 
 module.exports = gimme

--- a/lib/gimme.js
+++ b/lib/gimme.js
@@ -7,7 +7,7 @@ const { Readable } = require('stream')
 
 const {
   assoc, assocPath, evolve, flip, identity, is,
-  merge, pick, pipe, replace
+  length, merge, pick, pipe, replace, when
 } = require('ramda')
 
 const { parseBody, streamBody } = require('./body')
@@ -24,7 +24,7 @@ const gimme = opts => {
 
   const {
     data,
-    deserialize = json ? JSON.parse : identity,
+    deserialize = json ? parseJSON : identity,
     jwt,
     method      = 'GET',
     serialize   = json ? JSON.stringify : identity,
@@ -82,6 +82,8 @@ const gimme = opts => {
     }
   })
 }
+
+const parseJSON = when(length, JSON.parse)
 
 const wrapError = context => {
   const { statusCode, statusMessage } = context.res

--- a/lib/parseBody.js
+++ b/lib/parseBody.js
@@ -1,7 +1,7 @@
+const rawBody = require('raw-body')
+const typer   = require('media-typer')
+
 const { compose, curry, path } = require('ramda')
-const { PassThrough } = require('stream')
-const rawBody         = require('raw-body')
-const typer           = require('media-typer')
 
 const contentLength = compose(parseInt, path(['headers', 'content-length']))
 const contentType   = path(['headers', 'content-type'])
@@ -13,13 +13,4 @@ const parseBody = (deserialize, res) => {
   return rawBody(res, { encoding, length }).then(deserialize)
 }
 
-const streamBody = res => {
-  const body = new PassThrough()
-  res.pipe(body)
-  return Promise.resolve(body)
-}
-
-module.exports = {
-  parseBody: curry(parseBody),
-  streamBody
-}
+module.exports = curry(parseBody)

--- a/lib/streamBody.js
+++ b/lib/streamBody.js
@@ -1,0 +1,9 @@
+const { PassThrough } = require('stream')
+
+const streamBody = res => {
+  const body = new PassThrough()
+  res.pipe(body)
+  return Promise.resolve(body)
+}
+
+module.exports = streamBody

--- a/lib/wrapError.js
+++ b/lib/wrapError.js
@@ -1,0 +1,8 @@
+const Boom = require('boom')
+
+const wrapError = context => {
+  const { statusCode, statusMessage } = context.res
+  return Boom.create(statusCode, statusMessage, context)
+}
+
+module.exports = wrapError

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint .",
     "postversion": "git push --tags origin master",
     "preversion": "git checkout master",
-    "test": "mocha test --reporter=dot",
+    "test": "mocha --reporter=dot",
     "test:ci": "yarn lint && yarn test:coverage && yarn coverage",
     "test:coverage": "nyc yarn test"
   },

--- a/test/00-setup.js
+++ b/test/00-setup.js
@@ -30,6 +30,7 @@ beforeEach(() => {
   nock(url).get('/').query(true).reply(respond('GET'))
   nock(url).post('/').query(true).reply(respond('POST'))
   nock(url).get('/error').query(true).reply(400)
+  nock(url).get('/no-length').query(true).reply(200, { foo: 'bar' })
 })
 
 afterEach(() =>

--- a/test/deserialize.js
+++ b/test/deserialize.js
@@ -32,4 +32,15 @@ describe('deserialize', () => {
       expect(res().body).to.equal('{"body":"","headers":{"content-type":"application/json","host":"articulate.com"},"method":"GET","query":{},"uri":"/"}')
     )
   })
+
+  describe('when response has no content-length', () => {
+    beforeEach(() =>
+      gimme({ deserialize: identity, url: `${url}/no-length` }).then(res)
+    )
+
+    it('still parses and deserializes the body', () => {
+      expect(res().body).to.equal('{"foo":"bar"}')
+      expect(res().headers['content-length']).to.be.undefined
+    })
+  })
 })


### PR DESCRIPTION
![shrug](http://angriestprogrammer.com/comics/parsing.png)

Was getting `body: null` for responses that didn't include a `content-length` header.  If it has the header, we should check it, but if not, we should parse the body just fine.