### PR TITLE
Fix port bug

### DIFF
--- a/lib/gimme.js
+++ b/lib/gimme.js
@@ -37,7 +37,7 @@ const gimme = opts => {
 
   const headers = merge({}, opts.headers)
 
-  const { auth, host, pathname, port, protocol } = URL.parse(url)
+  const { auth, hostname, pathname, port, protocol } = URL.parse(url)
 
   if (json) headers['content-type']  = 'application/json'
   if (jwt)  headers['authorization'] = `Bearer ${jwt}`
@@ -46,7 +46,7 @@ const gimme = opts => {
     ? `${pathname}?${qs.stringify(data)}`
     : pathname
 
-  const params = { auth, headers, host, method, path, port, protocol }
+  const params = { auth, headers, hostname, method, path, port, protocol }
 
   return new Promise((resolve, reject) => {
     const respond = res => {

--- a/test/00-setup.js
+++ b/test/00-setup.js
@@ -4,8 +4,11 @@ const URL  = require('url')
 
 const { curry, compose, prop } = require('ramda')
 
-const surl = exports.surl = 'https://articulate.com'
-const url  = exports.url  = 'http://articulate.com'
+const portly = 'http://ported.com:1234'
+const surl   = 'https://secure.com'
+const url    = 'http://regular.com'
+
+Object.assign(exports, { portly, surl, url })
 
 const parseQuery = compose(qs.parse, prop('query'), URL.parse)
 
@@ -25,7 +28,10 @@ const respond = curry(function(method, uri, body) {
   return [ 200, resBody, headers ]
 })
 
+nock.disableNetConnect()
+
 beforeEach(() => {
+  nock(portly).get('/').query(true).reply(respond('GET'))
   nock(surl).get('/').query(true).reply(respond('GET'))
   nock(url).get('/').query(true).reply(respond('GET'))
   nock(url).post('/').query(true).reply(respond('POST'))

--- a/test/deserialize.js
+++ b/test/deserialize.js
@@ -29,7 +29,7 @@ describe('deserialize', () => {
     )
 
     it('deserializes correctly', () =>
-      expect(res().body).to.equal('{"body":"","headers":{"content-type":"application/json","host":"articulate.com"},"method":"GET","query":{},"uri":"/"}')
+      expect(res().body).to.equal('{"body":"","headers":{"content-type":"application/json","host":"regular.com"},"method":"GET","query":{},"uri":"/"}')
     )
   })
 

--- a/test/url.js
+++ b/test/url.js
@@ -2,8 +2,8 @@ const { expect } = require('chai')
 const property   = require('prop-factory')
 const URL        = require('url')
 
-const gimme         = require('..')
-const { surl, url } = require('./00-setup')
+const gimme = require('..')
+const { portly, surl, url } = require('./00-setup')
 
 describe('data', () => {
   const res  = property()
@@ -57,6 +57,19 @@ describe('data', () => {
     )
 
     it('supports that too', () => {
+      expect(res().body.uri).to.equal('/')
+      expect(res().body.headers['host']).to.equal(parts.host)
+    })
+  })
+
+  describe('when port included', () => {
+    const parts = URL.parse(portly)
+
+    beforeEach(() =>
+      gimme({ url: portly }).then(res)
+    )
+
+    it('handles the port correctly', () => {
       expect(res().body.uri).to.equal('/')
       expect(res().body.headers['host']).to.equal(parts.host)
     })


### PR DESCRIPTION
![port a bug](http://www.amazingbutterflies.com/graphics/insectlore/lgportabug.gif)

This one was weird.  Unable to dupe in tests, but real easy to dupe IRL.  Including a port on the url caused `http` to stack the host with the port, like this: `http://example.com:3000:3000`.  Which of course doesn't exist, so you get an `ENOTFOUND` error.

ping @pklingem 