### PR TITLE
Send query string on non-GET requests

### DIFF
--- a/API.md
+++ b/API.md
@@ -28,6 +28,7 @@ The following params are accepted:
 | `serialize` | `Function` | [`JSON.parse`](http://devdocs.io/javascript/global_objects/json/parse) | function with which to serialize the request body |
 | `stream` | `Boolean` | `false` | if `true`, the response `body` will be a [`stream.Readable`](http://devdocs.io/node/stream#stream_class_stream_readable) |
 | `url` | `String` | | **required:** the `url` of the request |
+| `query` | `Object` | | data to serialize and append to the url as a query string |
 
 #### `Response` object
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ const schema = Joi.object({
   method:      Joi.string().valid(http.METHODS),
   serialize:   Joi.func(),
   stream:      Joi.boolean(),
-  url:         Joi.string().required()
+  url:         Joi.string().required(),
+  query:       Joi.any(),
 })
 
 module.exports = composeP(gimme, validate(schema))

--- a/lib/gimme.js
+++ b/lib/gimme.js
@@ -43,11 +43,9 @@ const gimme = opts => {
   if (json) headers['content-type']  = 'application/json'
   if (jwt)  headers['authorization'] = `Bearer ${jwt}`
 
-  const searchParams = method === 'GET' ?
-    (query || data) :
-    query
-
-  const search = searchParams == null ? '' : `?${qs.stringify(searchParams)}`
+  const search = (query == null || Object.keys(query).length === 0)
+    ? ''
+    : `?${qs.stringify(query)}`
 
   const path = pathname + search
 

--- a/lib/gimme.js
+++ b/lib/gimme.js
@@ -32,7 +32,8 @@ const gimme = opts => {
     method      = 'GET',
     serialize   = json ? JSON.stringify : identity,
     stream      = false,
-    url
+    url,
+    query,
   } = opts
 
   const headers = merge({}, opts.headers)
@@ -42,9 +43,13 @@ const gimme = opts => {
   if (json) headers['content-type']  = 'application/json'
   if (jwt)  headers['authorization'] = `Bearer ${jwt}`
 
-  const path = method === 'GET' && data
-    ? `${pathname}?${qs.stringify(data)}`
-    : pathname
+  const searchParams = method === 'GET' ?
+    (query || data) :
+    query
+
+  const search = searchParams == null ? '' : `?${qs.stringify(searchParams)}`
+
+  const path = pathname + search
 
   const params = { auth, headers, hostname, method, path, port, protocol }
 

--- a/test/data.js
+++ b/test/data.js
@@ -13,16 +13,6 @@ describe('data', () => {
     res(undefined)
   })
 
-  describe('when method is GET', () => {
-    beforeEach(() =>
-      gimme({ data, url }).then(res)
-    )
-
-    it('serializes it as query params', () =>
-      expect(res().body.query).to.eql(data)
-    )
-  })
-
   describe('when method is not GET', () => {
     describe('and data is not a stream', () => {
       beforeEach(() =>

--- a/test/query.js
+++ b/test/query.js
@@ -1,0 +1,71 @@
+const { expect } = require('chai')
+const property   = require('prop-factory')
+const stream     = require('stream')
+
+const gimme   = require('..')
+const { url } = require('./00-setup')
+
+describe('query', () => {
+  const query = { foo: 'bar' }
+  const data  = { baz: 'bop' }
+  const res   = property()
+
+  beforeEach(() => {
+    res(undefined)
+  })
+
+  describe('when method is GET', () => {
+    it('serializes `query` as query params', () =>
+      gimme({ query, data, url })
+        .then(result => {
+          res(result)
+          expect(res().body.query).to.eql(query)
+        })
+    )
+
+    it('serializes `data` as query params when `query` is not defined', () =>
+      gimme({ data, url })
+        .then(result => {
+          res(result)
+          expect(res().body.query).to.eql(data)
+        })
+    )
+  })
+
+  describe('when method is not GET', () => {
+    describe('and data is not a stream', () => {
+      beforeEach(() =>
+        gimme({ data, query, method: 'POST', url }).then(res)
+      )
+
+      it('serializes it in the request body', () => {
+        expect(res().body.query).to.eql(query)
+        expect(res().body.body).to.eql(data)
+      })
+    })
+
+    describe('and data is a stream', () => {
+      const data  = new stream.PassThrough()
+      const value = 'some streamed data'
+
+      beforeEach(() => {
+        const promise = gimme({
+          data,
+          query,
+          deserialize: JSON.parse,
+          json: false,
+          method: 'POST',
+          url
+        }).then(res)
+
+        data.end(value)
+        return promise
+      })
+
+      it('pipes the data into the request', () => {
+        expect(res().body.query).to.eql(query)
+        expect(res().body.body).to.equal(value)
+      })
+    })
+  })
+})

--- a/test/query.js
+++ b/test/query.js
@@ -22,14 +22,6 @@ describe('query', () => {
           expect(res().body.query).to.eql(query)
         })
     )
-
-    it('serializes `data` as query params when `query` is not defined', () =>
-      gimme({ data, url })
-        .then(result => {
-          res(result)
-          expect(res().body.query).to.eql(data)
-        })
-    )
   })
 
   describe('when method is not GET', () => {


### PR DESCRIPTION
Accept a new `query` object that will get serialized as a query string & appended to the URL.

* If the method is `GET`, the new `query` object will be used as the query string. If `query` is undefined, then `data` will be used as the query string, just like today.

* If the method is anything other than `GET`, then the new `query` object will always be used as the query string, & `data` will always be the request body.