### PR TITLE
Handle JSON.parse failure

### DIFF
--- a/lib/gimme.js
+++ b/lib/gimme.js
@@ -6,7 +6,7 @@ const { Readable } = require('stream')
 
 const {
   assoc, assocPath, evolve, flip, identity, is,
-  length, merge, pick, pipe, replace, when
+  merge, pick, pipe, replace, tryCatch
 } = require('ramda')
 
 const parseBody  = require('./parseBody')
@@ -20,7 +20,7 @@ const clean = pipe(
   evolve({ headers: redact })
 )
 
-const parseJSON = when(length, JSON.parse)
+const parseJSON = tryCatch(JSON.parse, identity)
 
 const gimme = opts => {
   const { json = true } = opts

--- a/lib/gimme.js
+++ b/lib/gimme.js
@@ -6,7 +6,7 @@ const { Readable } = require('stream')
 
 const {
   assoc, assocPath, evolve, flip, identity, is,
-  merge, pick, pipe, replace, tryCatch
+  merge, nthArg, pick, pipe, replace, tryCatch
 } = require('ramda')
 
 const parseBody  = require('./parseBody')
@@ -20,7 +20,7 @@ const clean = pipe(
   evolve({ headers: redact })
 )
 
-const parseJSON = tryCatch(JSON.parse, identity)
+const parseJSON = tryCatch(JSON.parse, nthArg(1))
 
 const gimme = opts => {
   const { json = true } = opts

--- a/test/00-setup.js
+++ b/test/00-setup.js
@@ -37,6 +37,7 @@ beforeEach(() => {
   nock(url).post('/').query(true).reply(respond('POST'))
   nock(url).get('/error').query(true).reply(400)
   nock(url).get('/no-length').query(true).reply(200, { foo: 'bar' })
+  nock(url).get('/non-json-error').query(true).reply(400, 'string error')
 })
 
 afterEach(() =>

--- a/test/errors.js
+++ b/test/errors.js
@@ -11,6 +11,19 @@ describe('errors', () => {
     res(undefined)
   })
 
+  describe('non JSON formatted error', () => {
+    beforeEach(() =>
+      gimme({ url: `${url}/non-json-error` }).catch(res)
+    )
+
+    it('rejects with an appropriate Boom error', () => {
+      expect(res()).to.be.a('Error')
+      expect(res().isBoom).to.be.true
+      expect(res().output.statusCode).to.equal(400)
+      expect(res().data.res.body).to.equal('string error')
+    })
+  })
+
   describe('when statusCode >= 400', () => {
     beforeEach(() =>
       gimme({ url: `${url}/error` }).catch(res)


### PR DESCRIPTION
![](https://media.giphy.com/media/l4pTqdlMJVeqbxXry/giphy.gif)

Using `gimme` for the Dropbox API and if an invalid authorization code is sent (regardless if `json: true` is specified, it blows up trying to parse the non-JSON string.

```
(UnhandledPromiseRejectionWarning: SyntaxError: Unexpected token E in JSON at position 0
```

