### PR TITLE
Add `cry` prop to booms

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,7 +13,7 @@ gimme : { k: v } -> Promise Boom Response
 
 Accepts an object of request params, described below.
 
-Returns a [`Promise`](http://devdocs.io/javascript/global_objects/promise) that either resolves with a [`Response`](#response-object), or rejects with an appropriate [`Boom`](https://www.npmjs.com/package/boom) error for the status code of the response.
+Returns a [`Promise`](http://devdocs.io/javascript/global_objects/promise) that either resolves with a [`Response`](#response-object), or rejects with an appropriate [`Boom`](https://www.npmjs.com/package/boom) error for the status code of the response & a `cry` property to assist with error reporting.
 
 The following params are accepted:
 

--- a/lib/wrapError.js
+++ b/lib/wrapError.js
@@ -2,7 +2,9 @@ const Boom = require('boom')
 
 const wrapError = context => {
   const { statusCode, statusMessage } = context.res
-  return new Boom(statusMessage, { data: context, statusCode })
+  const boom = new Boom(statusMessage, { data: context, statusCode })
+  boom.cry = true
+  return boom
 }
 
 module.exports = wrapError

--- a/test/errors.js
+++ b/test/errors.js
@@ -21,6 +21,7 @@ describe('errors', () => {
       expect(res().isBoom).to.be.true
       expect(res().output.statusCode).to.equal(400)
       expect(res().data.res.body).to.equal('string error')
+      expect(res().cry).to.equal(true)
     })
   })
 
@@ -33,6 +34,7 @@ describe('errors', () => {
       expect(res()).to.be.a('Error')
       expect(res().isBoom).to.be.true
       expect(res().output.statusCode).to.equal(400)
+      expect(res().cry).to.equal(true)
     })
   })
 })


### PR DESCRIPTION
Add a `cry=true` property to Boom responses to help error reporters know which Booms are coming from another server.